### PR TITLE
feat: Visualize Dataset, Simpler Dataset implementation without padding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ cython_debug/
 
 # windsurf rules
 .windsurfrules
+cache

--- a/configs/sana_config/512ms/Sana_pacman.yaml
+++ b/configs/sana_config/512ms/Sana_pacman.yaml
@@ -22,7 +22,7 @@ model:
   aspect_ratio_type: ASPECT_RATIO_512
   multi_scale: false
   attn_type: linear
-  linear_head_dim: 32
+  linear_head_dim: 40
   ffn_type: glumbconv
   mlp_acts:
     - silu

--- a/configs/sana_config/512ms/Sana_pacman.yaml
+++ b/configs/sana_config/512ms/Sana_pacman.yaml
@@ -11,7 +11,7 @@ data:
   sort_dataset: false
 # model config
 model:
-  model: SanaMS_PACMAN_P1_D12
+  model: SanaMS_PACMAN_P1_D20
   image_size: 512
   in_channels: 3
   mixed_precision: fp16

--- a/configs/sana_config/512ms/Sana_pacman.yaml
+++ b/configs/sana_config/512ms/Sana_pacman.yaml
@@ -11,7 +11,7 @@ data:
   sort_dataset: false
 # model config
 model:
-  model: SanaMS_PACMAN_P1_D20
+  model: SanaMS_PACMAN_P1_D12
   image_size: 512
   in_channels: 3
   mixed_precision: fp16
@@ -22,7 +22,7 @@ model:
   aspect_ratio_type: ASPECT_RATIO_512
   multi_scale: false
   attn_type: linear
-  linear_head_dim: 40
+  linear_head_dim: 32
   ffn_type: glumbconv
   mlp_acts:
     - silu

--- a/configs/sana_config/512ms/Sana_pacman.yaml
+++ b/configs/sana_config/512ms/Sana_pacman.yaml
@@ -1,5 +1,5 @@
 data:
-  type: PacmanDataset
+  type: PacmanDatasetSimple
   data_dir: ["datasets/pacman"]  # Update with actual path
   resolution: 512
   sequence_length: 5  # Length of action sequences

--- a/diffusion/data/datasets/pacman_data.py
+++ b/diffusion/data/datasets/pacman_data.py
@@ -215,7 +215,7 @@ class PacmanDataset(IterableDataset):
         # Add noise to observation frames
         obs_frames = frames[:-C, :, :]  # Get observation frames
         noise = torch.randn_like(obs_frames)
-        noisy_obs = obs_frames + 0.3 * torch.rand(1).item() * noise  # Additive noise with random scaling
+        noisy_obs = obs_frames + 0.9 * torch.rand(1).item() * noise  # Additive noise with random scaling
         
         return {
             'obs': noisy_obs,  # [(seq_len-1)*C, H, W] with noise

--- a/diffusion/data/datasets/pacman_data.py
+++ b/diffusion/data/datasets/pacman_data.py
@@ -220,7 +220,7 @@ class PacmanDataset(IterableDataset):
         return {
             'obs': noisy_obs,  # [(seq_len-1)*C, H, W] with noise
             'img': frames[-C:, :, :],   # [C, H, W] 
-            'y': actions[:, :-1, :],  # [1, seq_len-1, 5]
+            'y': actions[:, 1:, :],  # [1, seq_len-1, 5], offset by -1
             'y_mask': torch.ones(1, actions.shape[1] - 1),  # [1, seq_len-1]
             'data_info': {
                 'episode': sequence[-1].get('episode', 0),

--- a/diffusion/data/datasets/pacman_data_simple.py
+++ b/diffusion/data/datasets/pacman_data_simple.py
@@ -1,0 +1,135 @@
+import torch
+from torch.utils.data import IterableDataset
+from collections import deque
+from datasets import load_dataset
+from PIL import Image
+from torchvision import transforms
+from diffusion.data.builder import DATASETS
+from diffusion.utils.logger import get_root_logger
+
+# Utility functions for image preprocessing
+
+def make_square(image):
+    """Pad image to square by adding black borders."""
+    width, height = image.size
+    max_dim = max(width, height)
+    padding = [
+        (max_dim - width) // 2,
+        (max_dim - height) // 2,
+        (max_dim - width + 1) // 2,
+        (max_dim - height + 1) // 2,
+    ]
+    return transforms.functional.pad(image, padding, fill=0, padding_mode='constant')
+
+
+def convert_to_rgb(img):
+    return img.convert("RGB")
+
+
+def rotate_90_clockwise(img):
+    return img.rotate(90, expand=True)
+
+def to_float16(x):
+    """Convert tensor to float16."""
+    return x.half()
+
+@DATASETS.register_module()
+class PacmanDatasetSimple(IterableDataset):
+    """
+    Simplified Pacman dataset without padding or background buffering.
+    Drop-in replacement for pacman_data_copy.PacmanDataset.
+    """
+    def __init__(
+        self,
+        data_dir="",
+        transform=None,
+        resolution=512,
+        load_vae_feat=False,
+        load_text_feat=False,
+        sequence_length=64,
+        buffer_size=None,
+        prefetch_factor=None,
+        config=None,
+        vae=None,
+        **kwargs,
+    ):
+        # Image transform pipeline
+        self.transform = transform or transforms.Compose([
+            transforms.Lambda(convert_to_rgb),
+            transforms.Lambda(make_square),
+            transforms.Resize(resolution),
+            transforms.functional.hflip,
+            transforms.Lambda(rotate_90_clockwise),
+            transforms.ToTensor(),
+            transforms.Lambda(to_float16),  # Convert to float16
+        ])
+        self.vae = vae
+        self.load_vae_feat = load_vae_feat
+        self.sequence_length = sequence_length
+        # One-hot cache for actions
+        self._cached_one_hot = {
+            i: torch.eye(5, dtype=torch.float32)[i] for i in range(5)
+        }
+        # Load streaming dataset
+        self.dataset = load_dataset(
+            "Tahahah/PacmanDataset_3",
+            split="train",
+            verification_mode="no_checks",
+            streaming=True,
+        )
+        # Sliding window buffer
+        self._buffer = deque(maxlen=self.sequence_length)
+
+    def __iter__(self):
+        """Yield processed sequences as dicts with keys: obs, img, y, y_mask, data_info."""
+        for sample in self.dataset:
+            self._buffer.append(sample)
+            if len(self._buffer) == self.sequence_length:
+                yield self._process_sequence(list(self._buffer))
+
+    def _process_sequence(self, sequence):
+        # Encode frames
+        frames = []
+        for b in sequence:
+            img = b['frame_image']
+            if self.vae is not None and self.load_vae_feat:
+                x = self.transform(img).unsqueeze(0).to(next(self.vae.parameters()).device)
+                z = self.vae.encoder(x).cpu().squeeze(0)
+                frames.append(z)
+            else:
+                frames.append(self.transform(img))
+        frames = torch.stack(frames)  # [L, C, H, W]
+        # Encode actions
+        actions = [self._cached_one_hot[b['action']] for b in sequence]
+        actions = torch.stack(actions).unsqueeze(0)  # [1, L, 5]
+        # Stagger offset logic
+        stagger_offset = 1
+        L = self.sequence_length
+        num_preds = max(L - stagger_offset - 1, 0)
+        # Observations
+        if num_preds > 0:
+            obs_seq = frames[stagger_offset : stagger_offset + num_preds]  # [num_preds, C, H, W]
+            obs = obs_seq.reshape(-1, frames.shape[2], frames.shape[3])  # [(num_preds*C), H, W]
+        else:
+            obs = torch.empty((0, frames.shape[2], frames.shape[3]))
+        # Target image
+        img = frames[-1]  # [C, H, W]
+        # Target actions and mask
+        y = actions[:, :num_preds, :]  # [1, num_preds, 5]
+        y_mask = torch.ones((1, num_preds), dtype=torch.float32)
+        # Data info
+        data_info = {
+            'episode': sequence[-1].get('episode', 0),
+            'done': sequence[-1].get('done', False),
+        }
+        return {
+            'obs': obs,
+            'img': img,
+            'y': y,
+            'y_mask': y_mask,
+            'data_info': data_info,
+        }
+
+    def __len__(self):
+        # Number of examples (approx) from the HF dataset
+        return self.dataset.info.splits['train'].num_examples

--- a/diffusion/model/nets/sana_multi_scale.py
+++ b/diffusion/model/nets/sana_multi_scale.py
@@ -433,3 +433,14 @@ def SanaMS_PACMAN_P1_D12(**kwargs):
         num_heads=16,
         **kwargs
     )
+
+@MODELS.register_module()
+def SanaMS_PACMAN_P1_D20(**kwargs):
+    """Factory function for PacmanDiffusionModel following Sana naming convention."""
+    return PacmanDiffusionModel(
+        depth=20,
+        hidden_size=512,
+        patch_size=1,
+        num_heads=20,
+        **kwargs
+    )

--- a/diffusion/model/nets/sana_multi_scale.py
+++ b/diffusion/model/nets/sana_multi_scale.py
@@ -439,7 +439,7 @@ def SanaMS_PACMAN_P1_D20(**kwargs):
     """Factory function for PacmanDiffusionModel following Sana naming convention."""
     return PacmanDiffusionModel(
         depth=20,
-        hidden_size=560,
+        hidden_size=640,
         patch_size=1,
         num_heads=20,
         **kwargs

--- a/diffusion/model/nets/sana_multi_scale.py
+++ b/diffusion/model/nets/sana_multi_scale.py
@@ -439,7 +439,7 @@ def SanaMS_PACMAN_P1_D20(**kwargs):
     """Factory function for PacmanDiffusionModel following Sana naming convention."""
     return PacmanDiffusionModel(
         depth=20,
-        hidden_size=512,
+        hidden_size=560,
         patch_size=1,
         num_heads=20,
         **kwargs

--- a/inference_pacman.py
+++ b/inference_pacman.py
@@ -395,10 +395,10 @@ def run_pacman_inference(config, args):
             keys = pygame.key.get_pressed()
             if not key_pressed:  # Only check if we haven't already processed a key event
                 if keys[pygame.K_LEFT]:
-                    current_action = 0
+                    current_action = 1
                     key_pressed = True
                 elif keys[pygame.K_RIGHT]:
-                    current_action = 1
+                    current_action = 0
                     key_pressed = True
                 elif keys[pygame.K_UP]:
                     current_action = 2
@@ -410,7 +410,7 @@ def run_pacman_inference(config, args):
         # Update action sequence
         # Create one-hot encoded action tensor for the current action
         new_action = torch.zeros(1, 1, 5, dtype=dtype, device=args.device)
-        new_action[0, 0, current_action] = 1.0
+        new_action[0, 0, current_action] = 1
         
         # Shift actions and add new action
         if actions_tensor.shape[1] > 1:

--- a/inference_pacman.py
+++ b/inference_pacman.py
@@ -395,10 +395,10 @@ def run_pacman_inference(config, args):
             keys = pygame.key.get_pressed()
             if not key_pressed:  # Only check if we haven't already processed a key event
                 if keys[pygame.K_LEFT]:
-                    current_action = 1
+                    current_action = 0
                     key_pressed = True
                 elif keys[pygame.K_RIGHT]:
-                    current_action = 0
+                    current_action = 1
                     key_pressed = True
                 elif keys[pygame.K_UP]:
                     current_action = 2

--- a/pacman_data_copy.py
+++ b/pacman_data_copy.py
@@ -1,0 +1,384 @@
+import torch
+from torch.utils.data import IterableDataset
+from torchvision import transforms
+from torchvision.transforms.functional import InterpolationMode
+from PIL import Image
+import os.path as osp
+import numpy as np
+from datasets import load_dataset
+from collections import deque
+from itertools import islice
+import threading
+import queue
+import traceback
+import logging
+from typing import Optional
+
+# from diffusion.data.datasets.utils import ASPECT_RATIO_512_TEST, ASPECT_RATIO_1024_TEST, ASPECT_RATIO_2048_TEST
+# from diffusion.data.builder import DATASETS
+# from diffusion.utils.logger import get_root_logger
+
+def make_square(image):
+    # Calculate the necessary padding to make the image square
+    width, height = image.size
+    max_dim = max(width, height)
+    padding = [
+        (max_dim - width) // 2,  # Left padding
+        (max_dim - height) // 2, # Top padding
+        (max_dim - width + 1) // 2,  # Right padding
+        (max_dim - height + 1) // 2  # Bottom padding
+    ]
+    return transforms.functional.pad(image, padding, fill=0, padding_mode='constant')
+
+def convert_to_rgb(img):
+    return img.convert("RGB")
+
+def rotate_90_clockwise(img):
+    return img.rotate(90, expand=True)
+
+def to_float16(x):
+    """Convert tensor to float16."""
+    return x.half()
+
+class PacmanIterator:
+    """Iterator class for PacmanDataset"""
+    def __init__(self, dataset):
+        self.dataset = dataset
+        self.dataset._init_worker_state()
+        
+        # Start processing thread if not already running
+        if self.dataset._worker_thread is None or not self.dataset._worker_thread.is_alive():
+            self.dataset._stop_event.clear()
+            self.dataset._worker_thread = threading.Thread(target=self.dataset._process_sequences, daemon=True)
+            self.dataset._worker_thread.start()
+    
+    def __iter__(self):
+        return self
+    
+    def __next__(self):
+        try:
+            # Try to get an item with timeout to avoid hanging
+            item = self.dataset.processed_sequences.get(timeout=1.0)
+            if item is None:  # Sentinel value
+                raise StopIteration
+            return item
+        except queue.Empty:
+            if not self.dataset._worker_thread.is_alive():
+                raise StopIteration
+            # If thread is still alive, try again
+            return self.__next__()
+        except Exception as e:
+            self.dataset.logger.error(f"Error in iterator: {e}")
+            self.dataset.stop_worker()
+            raise StopIteration
+
+# @DATASETS.register_module()
+class PacmanDataset(IterableDataset):
+    def __init__(
+        self,
+        data_dir="",  # Not used, kept for compatibility
+        transform=None,
+        resolution=512,
+        load_vae_feat=False,
+        load_text_feat=False,
+        sequence_length=64,
+        buffer_size=1000,  # Size of the sample buffer for batching
+        prefetch_factor=2,  # Number of batches to prefetch
+        config=None,
+        vae=None,  
+        **kwargs,
+    ):
+        self.logger = logging.Logger('lol') # if config is None else get_root_logger(osp.join(config.work_dir, "train_log.log"))
+        self.transform = transform if not load_vae_feat else None
+        self.load_vae_feat = load_vae_feat
+        self.load_text_feat = load_text_feat
+        self.resolution = resolution
+        self.sequence_length = sequence_length
+        self.buffer_size = buffer_size
+        self.prefetch_factor = prefetch_factor
+        self.vae = vae
+        self.config = config
+        # Default to fp32 if no config provided
+        self.mixed_precision = "fp32"
+        if config is not None and hasattr(config, 'model') and hasattr(config.model, 'mixed_precision'):
+            self.mixed_precision = config.model.mixed_precision
+        
+        # Create blank image for padding
+        self.blank_image = Image.new('RGB', (self.resolution, self.resolution), 'black')
+        self._cached_blank_frame = None
+        self._cached_blank_latent = None  
+        
+        # Cache for encoded frames
+        self._encoded_frames_cache = {}  # Maps frame hash to encoded frame
+        self._cache_size = sequence_length * 4  # Keep cache size reasonable
+        
+        # Load streaming dataset
+        self.dataset = load_dataset(
+            "Tahahah/PacmanDataset_3", 
+            split="train", 
+            verification_mode="no_checks", 
+            streaming=True
+        )
+
+        if not self.transform:
+            self.transform = transforms.Compose([
+                transforms.Lambda(convert_to_rgb),
+                transforms.Lambda(make_square),  # Make the image square with padding
+                transforms.Resize(self.resolution),          # Resize to 512x512
+                transforms.functional.hflip,     # Horizontal mirror flip
+                transforms.Lambda(rotate_90_clockwise),  # Rotate 90 degrees clockwise
+                transforms.ToTensor(),
+                transforms.Lambda(to_float16),  # Convert to float16
+            ])
+        
+        # Cache one-hot vectors in float16
+        self._cached_one_hot = {
+            i: torch.zeros(5, dtype=torch.float16).scatter_(0, torch.tensor(i), 1)
+            for i in range(5)
+        }
+        
+        self.logger.info(f"Initialized Pacman streaming dataset with buffer size {buffer_size}")
+        
+        # These will be initialized in worker processes
+        self.sample_buffer = None
+        self.sequence_buffer = None
+        self.processed_sequences = None
+        self._stop_event = None
+        self._worker_thread = None
+        
+    def _init_worker_state(self):
+        """Initialize worker-specific state (called in each worker process)"""
+        if self.sample_buffer is None:
+            self.sample_buffer = deque(maxlen=self.buffer_size)
+            self.sequence_buffer = deque(maxlen=self.sequence_length)
+            self.processed_sequences = queue.Queue(maxsize=self.prefetch_factor * self.buffer_size)
+            self._stop_event = threading.Event()
+            
+    def __iter__(self):
+        """Return an iterator over the dataset."""
+        worker_info = torch.utils.data.get_worker_info()
+        return PacmanIterator(self)
+
+    def __del__(self):
+        """Cleanup when the dataset is destroyed."""
+        try:
+            self.stop_worker()
+        except:
+            pass  # Ignore errors during cleanup
+
+    def stop_worker(self):
+        """Stop the prefetch worker thread."""
+        if hasattr(self, '_worker_thread') and self._worker_thread is not None:
+            if hasattr(self, '_stop_event'):
+                self._stop_event.set()
+            if self._worker_thread.is_alive():
+                try:
+                    self._worker_thread.join(timeout=0.1)  # Reduced timeout
+                except:
+                    pass  # Ignore join errors
+            self._worker_thread = None
+            
+    def _process_sequence(self, sequence):
+        """Process a sequence of samples into the required format."""
+        if len(sequence) < self.sequence_length:
+            # Pad with blanks at the start
+            padding_length = self.sequence_length - len(sequence)
+            if self.vae is not None and not self.load_vae_feat:
+                frames = ([self.blank_latent] * padding_length +
+                         [self._vae_encode_single(self.transform(b['frame_image'])) for b in sequence])
+            else:
+                frames = ([self.blank_frame] * padding_length +
+                         [self.transform(b['frame_image']) for b in sequence])
+            actions = ([self._one_hot_encode(4)] * padding_length +
+                     [self._one_hot_encode(b['action']) for b in sequence])
+        else:
+            # Use last sequence_length samples
+            if self.vae is not None and not self.load_vae_feat:
+                frames = [self._vae_encode_single(self.transform(b['frame_image'])) 
+                         for b in sequence[-self.sequence_length:]]
+            else:
+                frames = [self.transform(b['frame_image']) 
+                         for b in sequence[-self.sequence_length:]]
+            actions = [self._one_hot_encode(b['action']) 
+                      for b in sequence[-self.sequence_length:]]
+
+        # Stack tensors
+        frames = torch.stack(frames)  # [seq_len, C, H, W] or [seq_len, 32, 16, 16] if VAE encoded
+        actions = torch.stack(actions)  # [seq_len, 5]
+        
+        B, C, H, W = frames.shape
+        frames = frames.view(-1, H, W)  # Flatten sequence and channels
+            
+        # Reshape actions to match model's expected input shape: [1, seq_len, 5]
+        actions = actions.unsqueeze(0)  # Add batch dimension
+        
+        # Add noise to observation frames
+        obs_frames = frames[:-C, :, :]  # Get observation frames
+        noise = torch.randn_like(obs_frames)
+        noisy_obs = obs_frames #+ 0.9 * torch.rand(1).item() * noise  # Additive noise with random scaling
+        
+        return {
+            'obs': noisy_obs,  # [(seq_len-1)*C, H, W] with noise
+            'img': frames[-C:, :, :],   # [C, H, W] 
+            'y': actions[:, 1:, :],  # [1, seq_len-1, 5], offset by -1
+            'y_mask': torch.ones(1, actions.shape[1] - 1),  # [1, seq_len-1]
+            'data_info': {
+                'episode': sequence[-1].get('episode', 0),
+                'done': sequence[-1].get('done', False)
+            }
+        }
+
+    def _one_hot_encode(self, action, num_classes=5):
+        """Convert action to one-hot encoding.        
+            LEFT = 0
+            RIGHT = 1
+            UP = 2
+            DOWN = 3
+            NO_ACTION = 4
+        """
+        return self._cached_one_hot[action]
+    
+    def _fill_buffer(self):
+        """Fill the sample buffer with new samples efficiently."""
+        # Fill buffer in batches
+        batch_size = self.buffer_size - len(self.sample_buffer)
+        if batch_size <= 0:
+            return
+            
+        try:
+            # Get multiple samples at once
+            samples = list(islice(iter(self.dataset), batch_size))
+            self.sample_buffer.extend(samples)
+        except StopIteration:
+            pass
+
+    def _prefetch_worker(self):
+        """Background worker to prefetch and process sequences."""
+        while not self._stop_event.is_set():
+            try:
+                # Fill buffer if needed
+                self._fill_buffer()
+                if not self.sample_buffer:
+                    break
+                
+                # Get a batch of samples
+                batch_size = min(len(self.sample_buffer), self.buffer_size)
+                samples = [self.sample_buffer.popleft() for _ in range(batch_size)]
+                
+                # Process each sample
+                for sample in samples:
+                    if self._stop_event.is_set():
+                        return
+                    self.sequence_buffer.append(sample)
+                    if len(self.sequence_buffer) > 0:
+                        sequence = list(self.sequence_buffer)
+                        processed = self._process_sequence(sequence)
+                        self.processed_sequences.put(processed)
+            except Exception as e:
+                self.logger.error(f"Error in prefetch worker: {str(e)}\nTraceback:\n{traceback.format_exc()}")
+                break
+    
+    def _get_frame_hash(self, frame_image):
+        """Get a unique hash for a frame image for caching."""
+        if isinstance(frame_image, torch.Tensor):
+            # For tensors, use numpy bytes
+            return hash(frame_image.cpu().numpy().tobytes())
+        else:
+            # For PIL images, use image bytes
+            return hash(frame_image.tobytes())
+
+    def _vae_encode_single(self, frame):
+        """Encode a single frame, using cache if available."""
+        if self.vae is None or self.load_vae_feat:
+            return frame
+            
+        frame_hash = self._get_frame_hash(frame)
+        if frame_hash in self._encoded_frames_cache:
+            return self._encoded_frames_cache[frame_hash]
+            
+        try:
+            device = next(self.vae.parameters()).device
+            with torch.no_grad():
+                with torch.amp.autocast(
+                    "cuda",
+                    enabled=(self.mixed_precision == "fp16" or self.mixed_precision == "bf16"),
+                ):
+                    frame = frame.unsqueeze(0).to(device)  # Add batch dimension
+                    latent = self.vae.encoder(frame).cpu()  # Direct encoding without sampling
+                    
+                    # Cache the result
+                    self._encoded_frames_cache[frame_hash] = latent.squeeze(0)
+                    
+                    # Maintain cache size
+                    if len(self._encoded_frames_cache) > self._cache_size:
+                        # Remove oldest items
+                        oldest_key = next(iter(self._encoded_frames_cache))
+                        del self._encoded_frames_cache[oldest_key]
+                    
+                    return latent.squeeze(0)
+        except Exception as e:
+            self.logger.error(f"Error in VAE encoding: {str(e)}\nTraceback:\n{traceback.format_exc()}")
+            raise
+
+    @property
+    def blank_frame(self):
+        """Cached transformed blank frame."""
+        if self._cached_blank_frame is None:
+            self._cached_blank_frame = self.transform(self.blank_image)
+        return self._cached_blank_frame
+
+    @property
+    def blank_latent(self):
+        """Cached VAE-encoded blank frame."""
+        if self._cached_blank_latent is None and self.vae is not None:
+            with torch.no_grad():
+                frame = self.blank_frame.unsqueeze(0).to(next(self.vae.parameters()).device)
+                self._cached_blank_latent = self.vae.encoder(frame).cpu().squeeze(0)
+        return self._cached_blank_latent
+
+    def _process_sequences(self):
+        """Background worker to prefetch and process sequences."""
+        while not self._stop_event.is_set():
+            try:
+                # Fill buffer if needed
+                self._fill_buffer()
+                if not self.sample_buffer:
+                    break
+                
+                # Get a batch of samples
+                batch_size = min(len(self.sample_buffer), self.buffer_size)
+                samples = [self.sample_buffer.popleft() for _ in range(batch_size)]
+                
+                # Process each sample
+                for sample in samples:
+                    if self._stop_event.is_set():
+                        return
+                    self.sequence_buffer.append(sample)
+                    # Only emit sequences once we have a full window (no partial padding)
+                    if len(self.sequence_buffer) >= self.sequence_length:
+                        sequence = list(self.sequence_buffer)
+                        processed = self._process_sequence(sequence)
+                        self.processed_sequences.put(processed)
+            except Exception as e:
+                self.logger.error(f"Error in prefetch worker: {str(e)}\nTraceback:\n{traceback.format_exc()}")
+                break
+    
+    def __len__(self):
+        return self.dataset.info.splits['train'].num_examples
+
+# @DATASETS.register_module()
+class PacmanDatasetMS(PacmanDataset):
+    def __init__(self, aspect_ratio_type="ASPECT_RATIO_1024", **kwargs):
+        super().__init__(**kwargs)
+        # Add multi-scale specific initialization
+        try:
+            self.base_size = int(aspect_ratio_type.split("_")[2])  # Gets '512' from 'ASPECT_RATIO_512_TEST'
+        except (IndexError, ValueError):
+            self.base_size = 512
+            
+        self.aspect_ratio = eval(aspect_ratio_type)
+        self.interpolate_mode = InterpolationMode.BICUBIC
+
+    def __iter__(self):
+        for data in super().__iter__():
+            yield data

--- a/pacman_data_simple.py
+++ b/pacman_data_simple.py
@@ -1,0 +1,128 @@
+import torch
+from torch.utils.data import IterableDataset
+from collections import deque
+from datasets import load_dataset
+from PIL import Image
+from torchvision import transforms
+
+# Utility functions for image preprocessing
+
+def make_square(image):
+    """Pad image to square by adding black borders."""
+    width, height = image.size
+    max_dim = max(width, height)
+    padding = [
+        (max_dim - width) // 2,
+        (max_dim - height) // 2,
+        (max_dim - width + 1) // 2,
+        (max_dim - height + 1) // 2,
+    ]
+    return transforms.functional.pad(image, padding, fill=0, padding_mode='constant')
+
+
+def convert_to_rgb(img):
+    return img.convert("RGB")
+
+
+def rotate_90_clockwise(img):
+    return img.rotate(90, expand=True)
+
+
+class PacmanDataset(IterableDataset):
+    """
+    Simplified Pacman dataset without padding or background buffering.
+    Drop-in replacement for pacman_data_copy.PacmanDataset.
+    """
+    def __init__(
+        self,
+        data_dir="",
+        transform=None,
+        resolution=512,
+        load_vae_feat=False,
+        load_text_feat=False,
+        sequence_length=64,
+        buffer_size=None,
+        prefetch_factor=None,
+        config=None,
+        vae=None,
+        **kwargs,
+    ):
+        # Image transform pipeline
+        self.transform = transform or transforms.Compose([
+            transforms.Lambda(convert_to_rgb),
+            transforms.Lambda(make_square),
+            transforms.Resize(resolution),
+            transforms.functional.hflip,
+            transforms.Lambda(rotate_90_clockwise),
+            transforms.ToTensor(),
+        ])
+        self.vae = vae
+        self.load_vae_feat = load_vae_feat
+        self.sequence_length = sequence_length
+        # One-hot cache for actions
+        self._cached_one_hot = {
+            i: torch.eye(5, dtype=torch.float32)[i] for i in range(5)
+        }
+        # Load streaming dataset
+        self.dataset = load_dataset(
+            "Tahahah/PacmanDataset_3",
+            split="train",
+            verification_mode="no_checks",
+            streaming=True,
+        )
+        # Sliding window buffer
+        self._buffer = deque(maxlen=self.sequence_length)
+
+    def __iter__(self):
+        """Yield processed sequences as dicts with keys: obs, img, y, y_mask, data_info."""
+        for sample in self.dataset:
+            self._buffer.append(sample)
+            if len(self._buffer) == self.sequence_length:
+                yield self._process_sequence(list(self._buffer))
+
+    def _process_sequence(self, sequence):
+        # Encode frames
+        frames = []
+        for b in sequence:
+            img = b['frame_image']
+            if self.vae is not None and self.load_vae_feat:
+                x = self.transform(img).unsqueeze(0).to(next(self.vae.parameters()).device)
+                z = self.vae.encoder(x).cpu().squeeze(0)
+                frames.append(z)
+            else:
+                frames.append(self.transform(img))
+        frames = torch.stack(frames)  # [L, C, H, W]
+        # Encode actions
+        actions = [self._cached_one_hot[b['action']] for b in sequence]
+        actions = torch.stack(actions).unsqueeze(0)  # [1, L, 5]
+        # Stagger offset logic
+        stagger_offset = 1
+        L = self.sequence_length
+        num_preds = max(L - stagger_offset - 1, 0)
+        # Observations
+        if num_preds > 0:
+            obs_seq = frames[stagger_offset : stagger_offset + num_preds]  # [num_preds, C, H, W]
+            obs = obs_seq.reshape(-1, frames.shape[2], frames.shape[3])  # [(num_preds*C), H, W]
+        else:
+            obs = torch.empty((0, frames.shape[2], frames.shape[3]))
+        # Target image
+        img = frames[-1]  # [C, H, W]
+        # Target actions and mask
+        y = actions[:, :num_preds, :]  # [1, num_preds, 5]
+        y_mask = torch.ones((1, num_preds), dtype=torch.float32)
+        # Data info
+        data_info = {
+            'episode': sequence[-1].get('episode', 0),
+            'done': sequence[-1].get('done', False),
+        }
+        return {
+            'obs': obs,
+            'img': img,
+            'y': y,
+            'y_mask': y_mask,
+            'data_info': data_info,
+        }
+
+    def __len__(self):
+        # Number of examples (approx) from the HF dataset
+        return self.dataset.info.splits['train'].num_examples

--- a/visualize_model_input.py
+++ b/visualize_model_input.py
@@ -1,7 +1,8 @@
 import torch
 import matplotlib.pyplot as plt
 import numpy as np
-from pacman_data_copy import PacmanDataset
+import random
+from pacman_data_simple import PacmanDataset
 from torch.utils.data import DataLoader
 from matplotlib.widgets import Button
 
@@ -32,7 +33,7 @@ def plot_single_processed_sequence(processed_sequence_data, sequence_idx_in_dl_b
     'global_sequence_length' is the PacmanDataset's sequence_length parameter.
     """
     # User's preferred action labels (from Step 118)
-    action_labels = ["RIGHT", "LEFT", "UP", "DOWN", "NO_ACTION"]
+    action_labels = ["LEFT", "RIGHT", "UP", "DOWN", "NO_ACTION"]
 
     # Extract data for this single sequence
     obs_tensor_chw_total = processed_sequence_data['obs']  # Shape: [(L-1)*C, H, W]
@@ -40,7 +41,8 @@ def plot_single_processed_sequence(processed_sequence_data, sequence_idx_in_dl_b
     actions_tensor_1ls = processed_sequence_data['y']      # Shape: [1, L-1, NumActions]
 
     C = 3  # Assuming RGB
-    num_obs_frames = global_sequence_length - 1
+    # num_obs_frames is the number of prediction steps, which is the length of the 'y' sequence.
+    num_obs_frames = actions_tensor_1ls.shape[1] # Shape of y is [1, num_model_predictions, NumActions]
     
     # obs_tensor_chw_total has shape [(num_obs_frames)*C, H, W]
     # Reshape to [num_obs_frames, C, H, W]
@@ -97,6 +99,20 @@ def on_next_batch_click(event):
         print("DataLoader iterator not initialized.")
         return
 
+    # Skip a random number of batches (0 to 5) to get more varied sequences
+    num_to_skip = random.randint(0, 5)
+    if num_to_skip > 0:
+        print(f"Skipping {num_to_skip} batches to get a more random one...")
+        for _ in range(num_to_skip):
+            try:
+                _ = next(dataloader_iterator) # Consume and discard
+            except StopIteration:
+                print("DataLoader exhausted while skipping. Re-initializing iterator.")
+                dataloader_iterator = iter(dataloader_instance)
+                # If exhausted while skipping, we might not be able to skip fully.
+                # We'll just proceed to fetch the next available batch after this loop.
+                break 
+    
     print("Fetching next batch from DataLoader...")
     try:
         # This 'dl_batch' contains 'dataloader_batch_size' number of processed sequences

--- a/visualize_model_input.py
+++ b/visualize_model_input.py
@@ -1,0 +1,179 @@
+import torch
+import matplotlib.pyplot as plt
+import numpy as np
+from pacman_data_copy import PacmanDataset
+from torch.utils.data import DataLoader
+from matplotlib.widgets import Button
+
+# --- Globals for managing DataLoader state and figures ---
+dataloader_iterator = None
+dataloader_instance = None
+# To keep track of figures for each batch, so they can be closed
+# This list will store figure objects.
+active_figures = []
+
+def normalize_image_for_visualization(image_tensor_hwc):
+    """Normalizes a single image tensor (H, W, C) to [0,1] float32 for imshow."""
+    frame_np = image_tensor_hwc.numpy()
+    min_val = np.min(frame_np)
+    max_val = np.max(frame_np)
+    delta = max_val - min_val
+    if delta < 1e-7:  # Handle constant or near-constant frames
+        # Normalize to 0.5 (grey) if constant, ensuring it's float32
+        normalized_frame = np.full_like(frame_np, 0.5, dtype=np.float32)
+    else:
+        normalized_frame = (frame_np - min_val) / delta
+    return np.clip(normalized_frame, 0, 1).astype(np.float32)
+
+def plot_single_processed_sequence(processed_sequence_data, sequence_idx_in_dl_batch, total_sequences_in_dl_batch, global_sequence_length):
+    """
+    Plots a single processed sequence (obs, target img, actions) in a new figure.
+    'processed_sequence_data' is a dict for one item from the DataLoader's batch.
+    'global_sequence_length' is the PacmanDataset's sequence_length parameter.
+    """
+    # User's preferred action labels (from Step 118)
+    action_labels = ["RIGHT", "LEFT", "UP", "DOWN", "NO_ACTION"]
+
+    # Extract data for this single sequence
+    obs_tensor_chw_total = processed_sequence_data['obs']  # Shape: [(L-1)*C, H, W]
+    target_img_tensor_chw = processed_sequence_data['img']  # Shape: [C, H, W]
+    actions_tensor_1ls = processed_sequence_data['y']      # Shape: [1, L-1, NumActions]
+
+    C = 3  # Assuming RGB
+    num_obs_frames = global_sequence_length - 1
+    
+    # obs_tensor_chw_total has shape [(num_obs_frames)*C, H, W]
+    # Reshape to [num_obs_frames, C, H, W]
+    H_dim = obs_tensor_chw_total.shape[1]
+    W_dim = obs_tensor_chw_total.shape[2]
+    obs_reshaped_lchw = obs_tensor_chw_total.view(num_obs_frames, C, H_dim, W_dim)
+    
+    # Permute to [num_obs_frames, H, W, C] for visualization
+    obs_frames_torch_lhwc = obs_reshaped_lchw.permute(0, 2, 3, 1).cpu()
+
+    obs_frames_viz = [normalize_image_for_visualization(frame) for frame in obs_frames_torch_lhwc]
+    target_img_viz = normalize_image_for_visualization(target_img_tensor_chw.permute(1, 2, 0).cpu())
+
+    # Actions: from [1, L-1, NumActions] to [L-1] indices
+    action_indices_np = torch.argmax(actions_tensor_1ls.squeeze(0), dim=1).cpu().numpy()
+
+    # Create a new figure for this sequence
+    fig, axes = plt.subplots(3, num_obs_frames, figsize=(num_obs_frames * 2.5, 7.5))
+    if num_obs_frames == 1: # Adjust axes array shape if only one obs frame
+        axes = axes.reshape(3,1)
+
+    for i in range(num_obs_frames):
+        # Row 1: Observation frames
+        axes[0, i].imshow(obs_frames_viz[i])
+        axes[0, i].set_title(f"Obs Frame {i}")
+        axes[0, i].axis('off')
+        
+        # Row 2: Actions (shown below corresponding obs frame)
+        axes[1, i].imshow(obs_frames_viz[i]) # Show frame again for visual context
+        action_int_idx = int(action_indices_np[i])
+        action_name = action_labels[action_int_idx] if action_int_idx < len(action_labels) else "Unknown"
+        axes[1, i].set_title(f"Action: {action_name}")
+        axes[1, i].axis('off')
+        
+        # Row 3: Target Frame (repeated for alignment)
+        axes[2, i].imshow(target_img_viz)
+        axes[2, i].set_title(f"Target Img")
+        axes[2, i].axis('off')
+        
+    fig.suptitle(f"DataLoader Batch - Sequence {sequence_idx_in_dl_batch + 1}/{total_sequences_in_dl_batch}\n(Dataset seq_len={global_sequence_length})", fontsize=12)
+    plt.tight_layout(rect=[0, 0.03, 1, 0.93]) # Adjust rect for suptitle
+    return fig # Return the figure object
+
+def on_next_batch_click(event):
+    """Callback for the 'Next Batch' button."""
+    global dataloader_iterator, dataloader_instance, active_figures, dataset_sequence_length
+
+    # Close all previously opened sequence figures
+    for fig in active_figures:
+        plt.close(fig)
+    active_figures.clear()
+
+    if dataloader_iterator is None:
+        print("DataLoader iterator not initialized.")
+        return
+
+    print("Fetching next batch from DataLoader...")
+    try:
+        # This 'dl_batch' contains 'dataloader_batch_size' number of processed sequences
+        dl_batch = next(dataloader_iterator)
+    except StopIteration:
+        print("DataLoader exhausted. Re-initializing iterator.")
+        dataloader_iterator = iter(dataloader_instance) # Re-initialize
+        try:
+            dl_batch = next(dataloader_iterator)
+        except StopIteration:
+            print("DataLoader is empty even after re-initialization. Cannot fetch batch.")
+            return
+    
+    # The actual number of sequences in this DataLoader batch
+    # This should match dataloader_instance.batch_size
+    num_sequences_in_dl_batch = dl_batch['img'].shape[0] 
+    
+    print(f"Fetched DataLoader batch containing {num_sequences_in_dl_batch} sequences.")
+    print(f"  Shape of 'img' tensor in DL batch: {dl_batch['img'].shape}") # e.g., [seq_len, C, H, W]
+    print(f"  Shape of 'obs' tensor in DL batch: {dl_batch['obs'].shape}") # e.g., [seq_len, (L-1)*C, H, W]
+    print(f"  Shape of 'y' tensor in DL batch: {dl_batch['y'].shape}")       # e.g., [seq_len, 1, L-1, 5]
+
+    # Iterate through each processed sequence within this DataLoader batch
+    for i in range(num_sequences_in_dl_batch):
+        single_processed_sequence_data = {
+            'img': dl_batch['img'][i],
+            'obs': dl_batch['obs'][i],
+            'y': dl_batch['y'][i],
+            'y_mask': dl_batch['y_mask'][i]
+            # Add 'data_info' if necessary: 'data_info': dl_batch['data_info'][i] (if it's a list of dicts)
+        }
+        
+        new_fig = plot_single_processed_sequence(
+            single_processed_sequence_data,
+            sequence_idx_in_dl_batch=i,
+            total_sequences_in_dl_batch=num_sequences_in_dl_batch,
+            global_sequence_length=dataset_sequence_length # Pass the dataset's sequence_length
+        )
+        active_figures.append(new_fig)
+    
+    plt.show() # This will draw all newly created figures
+
+# Store dataset's sequence_length globally for access in callbacks
+dataset_sequence_length = 0
+
+def visualize_model_input(sequence_length_param=8, resolution_param=128):
+    """Main function to set up dataset, dataloader, button, and initial plot."""
+    global dataloader_iterator, dataloader_instance, active_figures, dataset_sequence_length
+
+    dataset_sequence_length = sequence_length_param # Store for later use
+
+    # User's PacmanDataset instantiation (from Step 118)
+    ds = PacmanDataset(transform=None, load_vae_feat=False, load_text_feat=False,
+                       sequence_length=sequence_length_param, resolution=resolution_param, 
+                       buffer_size=10, prefetch_factor=1) # User's buffer/prefetch
+    
+    # User's DataLoader batch_size setting (from Step 118)
+    # This means each item from dataloader_instance IS a batch of 'sequence_length_param' sequences
+    dataloader_batch_size = sequence_length_param 
+    dataloader_instance = DataLoader(ds, batch_size=dataloader_batch_size, num_workers=0, shuffle=False)
+    dataloader_iterator = iter(dataloader_instance)
+    
+    # --- Create a separate, persistent figure for the button ---
+    fig_button_control = plt.figure("Controls", figsize=(3, 1.5))
+    plt.subplots_adjust(bottom=0.3)
+    button_ax = plt.axes([0.15, 0.2, 0.7, 0.6]) # x, y, width, height
+    bnext = Button(button_ax, 'Next DataLoader Batch')
+    bnext.on_clicked(on_next_batch_click)
+    # We don't add fig_button_control to active_figures so it's not closed by on_next_batch_click
+
+    # Initial fetch and display of the first DataLoader batch
+    print("Displaying initial batch...")
+    on_next_batch_click(None) # Trigger initial plot
+    
+    plt.show() # Keeps all figures (including button) alive until manually closed
+
+if __name__ == '__main__':
+    # The 'batch_size' parameter for visualize_model_input is not directly used for DataLoader's batch_size here,
+    # as per user's existing DataLoader setup which uses sequence_length for its batch_size.
+    visualize_model_input(sequence_length_param=8, resolution_param=128)

--- a/visualize_pacman_dataset.py
+++ b/visualize_pacman_dataset.py
@@ -115,7 +115,7 @@ def main():
         )
         
         # Number of sequences to visualize
-        num_sequences = 3
+        num_sequences = 10
         # Number of frames per sequence - increase to account for staggering
         frames_per_sequence = 10  # Increased from 8 to allow for staggering
         # Stagger offset

--- a/visualize_pacman_dataset.py
+++ b/visualize_pacman_dataset.py
@@ -1,0 +1,168 @@
+import torch
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+import sys
+import traceback
+from datasets import load_dataset
+from PIL import Image
+from torchvision import transforms
+
+def make_square(image):
+    # Calculate the necessary padding to make the image square
+    width, height = image.size
+    max_dim = max(width, height)
+    padding = [
+        (max_dim - width) // 2,  # Left padding
+        (max_dim - height) // 2, # Top padding
+        (max_dim - width + 1) // 2,  # Right padding
+        (max_dim - height + 1) // 2  # Bottom padding
+    ]
+    return transforms.functional.pad(image, padding, fill=0, padding_mode='constant')
+
+def convert_to_rgb(img):
+    return img.convert("RGB")
+
+def rotate_90_clockwise(img):
+    return img.rotate(90, expand=True)
+
+def to_float16(x):
+    """Convert tensor to float16."""
+    return x.half()
+
+def visualize_sequence(sequence, sequence_idx, save_dir=".", stagger_offset=2):
+    """
+    Visualize a sequence from the Pacman dataset with staggered actions
+    
+    Args:
+        sequence: A list of dictionaries containing frame_image and action
+        sequence_idx: Index of the sequence for naming the output file
+        save_dir: Directory to save the visualization
+        stagger_offset: Number of frames to offset the actions by (backward)
+    
+    Returns:
+        Path to the saved visualization image
+    """
+    # Define action labels
+    action_labels = ["LEFT", "RIGHT", "UP", "DOWN", "NO_ACTION"]
+    
+    # Create a transform pipeline
+    transform = transforms.Compose([
+        transforms.Lambda(convert_to_rgb),
+        transforms.Lambda(make_square),  # Make the image square with padding
+        transforms.Resize(512),          # Resize to 512x512
+        transforms.functional.hflip,     # Horizontal mirror flip
+        transforms.Lambda(rotate_90_clockwise),  # Rotate 90 degrees clockwise
+        transforms.ToTensor(),
+    ])
+    
+    # Get the number of frames in the sequence
+    seq_len = len(sequence)
+    
+    # Create a figure to display the sequence
+    fig, axes = plt.subplots(seq_len, 1, figsize=(10, seq_len * 3))
+    if seq_len == 1:
+        axes = [axes]
+    
+    plt.suptitle(f"Sequence {sequence_idx} - Pacman Frames (Actions from {stagger_offset} Frames Ago)", fontsize=16)
+    
+    # Plot each frame in the sequence
+    for i, frame_data in enumerate(sequence):
+        # Get the frame image
+        frame_image = frame_data["frame_image"]
+        
+        # Get the staggered action (from a past frame)
+        staggered_idx = i - stagger_offset
+        if staggered_idx >= 0:
+            action = sequence[staggered_idx]["action"]
+            action_text = f"Action from {stagger_offset} frames ago: {action_labels[action]}"
+        else:
+            # For frames near the beginning where we don't have a past action
+            action_text = "No past action available"
+        
+        # Transform the image
+        frame_tensor = transform(frame_image)
+        
+        # Convert tensor to numpy for display
+        frame_array = frame_tensor.permute(1, 2, 0).numpy()
+        
+        # Display the frame
+        axes[i].imshow(frame_array)
+        axes[i].set_title(f"Frame {i} - {action_text}")
+        axes[i].axis('off')
+    
+    plt.tight_layout()
+    save_path = os.path.join(save_dir, f"pacman_sequence_{sequence_idx}_staggered.png")
+    plt.savefig(save_path)
+    plt.close()
+    
+    return save_path
+
+def main():
+    try:
+        # Create output directory if it doesn't exist
+        output_dir = "pacman_visualizations"
+        os.makedirs(output_dir, exist_ok=True)
+        
+        print("Loading Pacman dataset from Hugging Face...")
+        
+        # Load the dataset directly from Hugging Face
+        dataset = load_dataset(
+            "Tahahah/PacmanDataset_3", 
+            split="train", 
+            verification_mode="no_checks", 
+            streaming=True
+        )
+        
+        # Number of sequences to visualize
+        num_sequences = 3
+        # Number of frames per sequence - increase to account for staggering
+        frames_per_sequence = 10  # Increased from 8 to allow for staggering
+        # Stagger offset
+        stagger_offset = 2
+        
+        saved_images = []
+        
+        print(f"Visualizing {num_sequences} sequences with {frames_per_sequence} frames each...")
+        print(f"Actions will be staggered by {stagger_offset} frames")
+        
+        # Create an iterator
+        dataset_iter = iter(dataset)
+        
+        # Get and visualize sequences
+        for i in range(num_sequences):
+            try:
+                print(f"Processing sequence {i+1}/{num_sequences}")
+                
+                # Collect frames for this sequence
+                sequence = []
+                for j in range(frames_per_sequence):
+                    try:
+                        sample = next(dataset_iter)
+                        sequence.append(sample)
+                    except StopIteration:
+                        print("Reached the end of the dataset")
+                        break
+                
+                if not sequence:
+                    break
+                
+                # Visualize the sequence with staggered actions
+                saved_img = visualize_sequence(sequence, i+1, output_dir, stagger_offset)
+                saved_images.append(saved_img)
+                
+                print(f"Saved visualization to {saved_img}")
+                
+            except Exception as e:
+                print(f"Error processing sequence {i+1}: {str(e)}")
+                print(traceback.format_exc())
+        
+        print("\nVisualization complete!")
+        print(f"Saved images: {saved_images}")
+    
+    except Exception as e:
+        print(f"Error in main function: {str(e)}")
+        print(traceback.format_exc())
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Current Implementation (pacman_data_simple.py):
- Simple, single-threaded processing
- No prefetching - processes data on demand
- Potentially slower during training, as the main thread has to wait for data processing
- Much simpler, more reliable code with fewer potential bugs

Both visualization scripts visualize_model_input.py and visualize_pacman_dataset.py show correct action and frame pairing with the correct action stagger offset. i.e: The consequence of the action taken on current frame is reflected in the target frame.
![Figure_9](https://github.com/user-attachments/assets/09d2e4f9-8f5d-46e4-bf04-22f2fb43e493)
![Figure_4](https://github.com/user-attachments/assets/9c05705a-302c-499b-bd3e-5a2ba066b73f)
